### PR TITLE
Play nice with fold indicators branch

### DIFF
--- a/stylesheets/bookmarks.less
+++ b/stylesheets/bookmarks.less
@@ -1,9 +1,12 @@
 @import "octicon-utf-codes.less";
 
-.editor .gutter .line-number.bookmarked:after {
-  color: #09C;
-  content: @bookmark;
+.editor .gutter .line-number.bookmarked .icon-right {
   visibility: visible;
+
+  &:before {
+    content: @bookmark;
+    color: #09C;
+  }
 }
 
 .bookmarks-view {


### PR DESCRIPTION
This PR just tweaks some CSS to blend in with the new `.icon-right` element on the fold indicators branch.
