### PR TITLE
f2 conflicts with file tree:rename

### DIFF
--- a/keymaps/bookmarks.cson
+++ b/keymaps/bookmarks.cson
@@ -1,6 +1,6 @@
 'atom-text-editor':
   'ctrl-f2': 'bookmarks:view-all'
-  'f2': 'bookmarks:jump-to-next-bookmark'
+  'alt+f2': 'bookmarks:jump-to-next-bookmark'
   'shift-f2': 'bookmarks:jump-to-previous-bookmark'
 
 '.platform-darwin atom-text-editor':


### PR DESCRIPTION
The f2 should be for renaming conventions so changed f2 to alt+f2