### PR TITLE
Changed Linux keybinding for bookmarks:view-all.

### DIFF
--- a/keymaps/bookmarks.cson
+++ b/keymaps/bookmarks.cson
@@ -1,16 +1,18 @@
 'atom-text-editor':
-  'ctrl-f2': 'bookmarks:view-all'
   'f2': 'bookmarks:jump-to-next-bookmark'
   'shift-f2': 'bookmarks:jump-to-previous-bookmark'
 
 '.platform-darwin atom-text-editor':
+  'ctrl-f2': 'bookmarks:view-all'
   'cmd-f2': 'bookmarks:toggle-bookmark'
   'cmd-shift-f2': 'bookmarks:clear-bookmarks'
 
 '.platform-win32 atom-text-editor':
+  'ctrl-f2': 'bookmarks:view-all'
   'alt-ctrl-f2': 'bookmarks:toggle-bookmark'
   'ctrl-shift-f2': 'bookmarks:clear-bookmarks'
 
 '.platform-linux atom-text-editor':
+  'ctrl-alt-f2': 'bookmarks:view-all'
   'ctrl-shift-f2': 'bookmarks:toggle-bookmark'
   'alt-shift-f2': 'bookmarks:clear-bookmarks'


### PR DESCRIPTION
ctrl-f2 -> ctrl-alt-f2

This remedies conflict with default keybindings in xfce window manager.