### PR TITLE
Update README key list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,43 @@
 
 Bookmark lines in the editor.
 
-* `cmd-f2` to add/remove a bookmark on the current line
-* `cmd-shift-f2` to remove all bookmarks in the current editor
-* `ctrl-f2` to view all the bookmarks
-* `f2` to move the cursor to the next bookmark
-* `shift-f2` to move the cursor to the previous bookmark.
+![Screenshot](https://f.cloud.github.com/assets/671378/2241326/a060a70a-9ccb-11e3-9e5a-a9de23eb91af.png)
 
-![](https://f.cloud.github.com/assets/671378/2241326/a060a70a-9ccb-11e3-9e5a-a9de23eb91af.png)
+## Keys
+
+<table>
+    <thead>
+        <tr>
+            <th></th>
+            <th>Mac OS</th>
+            <th>GNU/Linux</th>
+            <th>Windows</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>Add/remove a bookmark on the current line </th>
+            <td align="center"><kbd>cmd-f2</kbd></td>
+            <td align="center"><kbd>ctrl-shift-f2</kbd></td>
+            <td align="center"><kbd>alt-ctrl-f2</kbd></td>
+        </tr>
+        <tr>
+            <th>Remove all bookmarks in the current editor</th>
+            <td align="center"><kbd>cmd-shift-f2</kbd></td>
+            <td align="center"><kbd>ctrl-shift-f2</kbd></td>
+            <td align="center"><kbd>alt-shift-f2</kbd></td>
+        </tr>
+        <tr>
+            <th>View all the bookmarks</th>
+            <td colspan="3" align="center"><kbd>ctrl-f2</kbd></td>
+        </tr>
+        <tr>
+            <th>Move the cursor to the next bookmark</th>
+            <td colspan="3" align="center"><kbd>f2</kbd></td>
+        </tr>
+        <tr>
+            <th>Move the cursor to the previous bookmark.</th>
+            <td colspan="3" align="center"><kbd>shift-f2</kbd></td>
+        </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
Add all key bindings to the README, so that users can easily see all keys on the package page. HTML table is used because I found no way of specifying `colspan` withing the Markdown.

![screen3](https://cloud.githubusercontent.com/assets/7157049/7427549/d1966a04-efd5-11e4-86c9-3e49d9b263f7.png)
