### PR TITLE
Avoid relying on className in specs

### DIFF
--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -48,7 +48,7 @@ describe "Bookmarks package", ->
 
       lines = editorElement.shadowRoot.querySelectorAll('.bookmarked')
       expect(lines.length).toEqual 1
-      expect(lines[0]).toHaveClass 'line-number-3'
+      expect(lines[0]).toHaveData("buffer-row", 3)
 
       atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
       expect(editorElement.shadowRoot.querySelectorAll('.bookmarked').length).toBe 0


### PR DESCRIPTION
So that we're free to optimize Style Recalculation.

Refs: atom/atom#8730