### PR TITLE
Keybindings for other platforms in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,29 @@
 
 Bookmark lines in the editor.
 
+### Keybindings
+
+
+#### Mac
+
 * `cmd-f2` to add/remove a bookmark on the current line
 * `cmd-shift-f2` to remove all bookmarks in the current editor
+* `ctrl-f2` to view all the bookmarks
+* `f2` to move the cursor to the next bookmark
+* `shift-f2` to move the cursor to the previous bookmark.
+
+#### Windows
+
+* `alt-ctrl-f2` to add/remove a bookmark on the current line
+* `ctrl-shift-f2` to remove all bookmarks in the current editor
+* `ctrl-f2` to view all the bookmarks
+* `f2` to move the cursor to the next bookmark
+* `shift-f2` to move the cursor to the previous bookmark.
+
+#### Linux
+
+* `ctrl-shift-f2` to add/remove a bookmark on the current line
+* `alt-shift-f2` to remove all bookmarks in the current editor
 * `ctrl-f2` to view all the bookmarks
 * `f2` to move the cursor to the next bookmark
 * `shift-f2` to move the cursor to the previous bookmark.

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ Bookmark lines in the editor.
 * `f2` to move the cursor to the next bookmark
 * `shift-f2` to move the cursor to the previous bookmark.
 
-![](https://f.cloud.github.com/assets/671378/2241326/a060a70a-9ccb-11e3-9e5a-a9de23eb91af.png)
+![](https://cloud.githubusercontent.com/assets/1545996/10418088/c6835598-7016-11e5-82a5-e9e653b639d0.png)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Bookmark lines in the editor.
 
 ### Keybindings
 
-
 #### Mac
 
 * `cmd-f2` to add/remove a bookmark on the current line
@@ -29,4 +28,4 @@ Bookmark lines in the editor.
 * `f2` to move the cursor to the next bookmark
 * `shift-f2` to move the cursor to the previous bookmark.
 
-![](https://cloud.githubusercontent.com/assets/1545996/10418088/c6835598-7016-11e5-82a5-e9e653b639d0.png)
+![atom-bookmarks-readme](https://cloud.githubusercontent.com/assets/1545996/10419203/97d75e32-7035-11e5-818f-5b34d60865c1.png)


### PR DESCRIPTION
Keybindings are in bullet lists, instead of tables as in atom/bookmarks#29

This really needs to exist somewhere. Being new to Atom, I only stumbled upon these bindings when browsing the repo, hoping to learn how to implement them.