### PR TITLE
Implement ranged single- and multi-line bookmarks

### DIFF
--- a/lib/bookmarks-view.coffee
+++ b/lib/bookmarks-view.coffee
@@ -57,10 +57,13 @@ class BookmarksView extends SelectListView
 
   viewForItem: (bookmark) ->
     bookmarkRow = bookmark.marker.getStartPosition().row
+    bookmarkEndRow = bookmark.marker.getEndPosition().row
     if filePath = bookmark.buffer.getPath()
       bookmarkLocation = "#{path.basename(filePath)}:#{bookmarkRow + 1}"
     else
       bookmarkLocation = "untitled:#{bookmarkRow + 1}"
+    if bookmarkRow isnt bookmarkEndRow
+      bookmarkLocation += "-#{bookmarkEndRow + 1}"
     lineText = @getLineText(bookmark)
 
     $$ ->

--- a/lib/bookmarks-view.coffee
+++ b/lib/bookmarks-view.coffee
@@ -56,13 +56,13 @@ class BookmarksView extends SelectListView
     @setItems(bookmarks)
 
   viewForItem: (bookmark) ->
-    bookmarkRow = bookmark.marker.getStartPosition().row
+    bookmarkStartRow = bookmark.marker.getStartPosition().row
     bookmarkEndRow = bookmark.marker.getEndPosition().row
     if filePath = bookmark.buffer.getPath()
-      bookmarkLocation = "#{path.basename(filePath)}:#{bookmarkRow + 1}"
+      bookmarkLocation = "#{path.basename(filePath)}:#{bookmarkStartRow + 1}"
     else
-      bookmarkLocation = "untitled:#{bookmarkRow + 1}"
-    if bookmarkRow isnt bookmarkEndRow
+      bookmarkLocation = "untitled:#{bookmarkStartRow + 1}"
+    if bookmarkStartRow isnt bookmarkEndRow
       bookmarkLocation += "-#{bookmarkEndRow + 1}"
     lineText = @getLineText(bookmark)
 

--- a/lib/bookmarks.coffee
+++ b/lib/bookmarks.coffee
@@ -20,13 +20,13 @@ class ReactBookmarks
   toggleBookmark: =>
     cursors = @editor.getCursors()
     for cursor in cursors
-      position = cursor.getBufferPosition()
-      bookmarks = @findBookmarkMarkers(startBufferRow: position.row)
+      range = @editor.getSelectedBufferRange()
+      bookmarks = @findBookmarkMarkers(intersectsBufferRowRange: [range.start.row, range.end.row])
 
       if bookmarks?.length > 0
         bookmark.destroy() for bookmark in bookmarks
       else
-        @createBookmarkMarker(position.row)
+        @createBookmarkMarker(range)
 
   addDecorationsForBookmarks: =>
     for bookmark in @findBookmarkMarkers() when bookmark.isValid()
@@ -45,7 +45,7 @@ class ReactBookmarks
 
   jumpToBookmark: (getBookmarkFunction) =>
     cursor = @editor.getLastCursor()
-    position = cursor.getBufferPosition()
+    position = cursor.getMarker().getStartBufferPosition()
     bookmarkMarker = @[getBookmarkFunction](position.row)
 
     if bookmarkMarker
@@ -79,8 +79,7 @@ class ReactBookmarks
 
     markers[bookmarkIndex]
 
-  createBookmarkMarker: (bufferRow) ->
-    range = [[bufferRow, 0], [bufferRow, 0]]
+  createBookmarkMarker: (range) ->
     bookmark = @displayBuffer().markBufferRange(range, @bookmarkMarkerAttributes(invalidate: 'surround'))
     @subscribe bookmark.onDidChange ({isValid}) ->
       bookmark.destroy() unless isValid

--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -20,25 +20,101 @@ describe "Bookmarks package", ->
       spyOn(atom, 'beep')
 
   describe "toggling bookmarks", ->
-    it "creates a marker when toggled", ->
-      editor.setCursorBufferPosition([3, 10])
-      expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+    describe "point marker bookmark", ->
+      it "creates a marker when toggled", ->
+        editor.setCursorBufferPosition([3, 10])
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
 
-      atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
-      markers = editor.findMarkers(class: 'bookmark')
-      expect(markers.length).toEqual 1
-      expect(markers[0].getBufferRange()).toEqual [[3, 0], [3, 0]]
+        markers = editor.findMarkers(class: 'bookmark')
+        expect(markers.length).toEqual 1
+        expect(markers[0].getBufferRange()).toEqual [[3, 10], [3, 10]]
 
-    it "removes marker when toggled", ->
-      editor.setCursorBufferPosition([3, 10])
-      expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+      it "removes marker when toggled", ->
+        editor.setCursorBufferPosition([3, 10])
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
 
-      atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-      expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
 
-      atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-      expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+    describe "single line range marker bookmark", ->
+      it "created a marker when toggled", ->
+        editor.setSelectedBufferRanges([[[3, 5], [3, 10]]])
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+
+        markers = editor.findMarkers(class: 'bookmark')
+        expect(markers.length).toEqual 1
+        expect(markers[0].getBufferRange()).toEqual [[3, 5], [3, 10]]
+
+      it "removes marker when toggled", ->
+        editor.setSelectedBufferRanges([[[3, 5], [3, 10]]])
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+    describe "multi line range marker bookmark", ->
+      it "created a marker when toggled", ->
+        editor.setSelectedBufferRanges([[[1, 5], [3, 10]]])
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+
+        markers = editor.findMarkers(class: 'bookmark')
+        expect(markers.length).toEqual 1
+        expect(markers[0].getBufferRange()).toEqual [[1, 5], [3, 10]]
+
+      it "removes marker when toggled", ->
+        editor.setSelectedBufferRanges([[[1, 5], [3, 10]]])
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+      it "removes marker when toggled inside bookmark", ->
+        editor.setSelectedBufferRanges([[[1, 5], [3, 10]]])
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+
+        editor.setCursorBufferPosition([2, 2])
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+      it "removes marker when toggled outside bookmark on start row", ->
+        editor.setSelectedBufferRanges([[[1, 5], [3, 10]]])
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+
+        editor.setCursorBufferPosition([1, 2])
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+      it "removes marker when toggled outside bookmark on end row", ->
+        editor.setSelectedBufferRanges([[[1, 5], [3, 8]]])
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+
+        editor.setCursorBufferPosition([3, 10])
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
 
     it "toggles proper classes on proper gutter row", ->
       editor.setCursorBufferPosition([3, 10])
@@ -128,7 +204,7 @@ describe "Bookmarks package", ->
         editor.setCursorBufferPosition([2, 0])
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
-        editor.setCursorBufferPosition([10, 0])
+        editor.setSelectedBufferRanges([[[8, 4], [10, 2]]])
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
       it "jump-to-next-bookmark finds next bookmark", ->
@@ -138,7 +214,7 @@ describe "Bookmarks package", ->
         expect(editor.getLastCursor().getBufferPosition()).toEqual [2, 0]
 
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-next-bookmark'
-        expect(editor.getLastCursor().getBufferPosition()).toEqual [10, 0]
+        expect(editor.getLastCursor().getMarker().getBufferRange()).toEqual [[8, 4], [10, 0]]
 
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-next-bookmark'
         expect(editor.getLastCursor().getBufferPosition()).toEqual [2, 0]
@@ -152,18 +228,18 @@ describe "Bookmarks package", ->
         editor.setCursorBufferPosition([0, 0])
 
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
-        expect(editor.getLastCursor().getBufferPosition()).toEqual [10, 0]
+        expect(editor.getLastCursor().getMarker().getBufferRange()).toEqual [[8, 4], [10, 0]]
 
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
         expect(editor.getLastCursor().getBufferPosition()).toEqual [2, 0]
 
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
-        expect(editor.getLastCursor().getBufferPosition()).toEqual [10, 0]
+        expect(editor.getLastCursor().getMarker().getBufferRange()).toEqual [[8, 4], [10, 0]]
 
         editor.setCursorBufferPosition([11, 0])
 
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
-        expect(editor.getLastCursor().getBufferPosition()).toEqual [10, 0]
+        expect(editor.getLastCursor().getMarker().getBufferRange()).toEqual [[8, 4], [10, 0]]
 
   describe "browsing bookmarks", ->
     it "displays a select list of all bookmarks", ->

--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -204,7 +204,7 @@ describe "Bookmarks package", ->
         editor.setCursorBufferPosition([2, 0])
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
-        editor.setSelectedBufferRanges([[[8, 4], [10, 2]]])
+        editor.setSelectedBufferRanges([[[8, 4], [10, 0]]])
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
       it "jump-to-next-bookmark finds next bookmark", ->


### PR DESCRIPTION
Have bookmarks remember their column and row instead of just row and also keep
track of their ending position.

Fixes #9 

Jumping forward/back:

![bookmarks_jump](https://cloud.githubusercontent.com/assets/2193314/10720432/50ae6bac-7b54-11e5-8fb8-0616c2d82094.gif)

Toggling:

![bookmarks_toggle](https://cloud.githubusercontent.com/assets/2193314/10720446/7de903ac-7b54-11e5-926f-0ba0188564b7.gif)

Bookmark view with multi-line bookmarks:

![bookmarks_view](https://cloud.githubusercontent.com/assets/2193314/10720448/848ff012-7b54-11e5-8dd3-ab26fa5b82fe.png)
