### PR TITLE
Use TextEditor APIs instead of private, deprecated displayBuffer field

### DIFF
--- a/lib/bookmarks.coffee
+++ b/lib/bookmarks.coffee
@@ -81,17 +81,14 @@ class ReactBookmarks
     markers[bookmarkIndex]
 
   createBookmarkMarker: (range) ->
-    bookmark = @displayBuffer().markBufferRange(range, @bookmarkMarkerAttributes(invalidate: 'surround'))
+    bookmark = @editor.markBufferRange(range, @bookmarkMarkerAttributes(invalidate: 'surround'))
     @subscribe bookmark.onDidChange ({isValid}) ->
       bookmark.destroy() unless isValid
     @editor.decorateMarker(bookmark, {type: 'line-number', class: 'bookmarked'})
     bookmark
 
   findBookmarkMarkers: (attributes={}) ->
-    @displayBuffer().findMarkers(@bookmarkMarkerAttributes(attributes))
+    @editor.findMarkers(@bookmarkMarkerAttributes(attributes))
 
   bookmarkMarkerAttributes: (attributes={}) ->
     _.extend(attributes, class: 'bookmark')
-
-  displayBuffer: ->
-    @editor.displayBuffer


### PR DESCRIPTION
At some point these methods probably weren't available, but that was a long time ago.