### PR TITLE
Use MarkerLayers and refactor package

### DIFF
--- a/lib/bookmarks-view.coffee
+++ b/lib/bookmarks-view.coffee
@@ -82,6 +82,6 @@ class BookmarksView extends SelectListView
       super
 
   confirmed: ({editor, marker}) ->
-    atom.workspace.open(editor.getPath(), searchAllPanes: true).then (editor) ->
-      editor.setSelectedBufferRange?(marker.getBufferRange(), autoscroll: true)
+    editor.setSelectedBufferRange(marker.getBufferRange(), autoscroll: true)
+    atom.workspace.paneForItem(editor).activate()
     @cancel()

--- a/lib/bookmarks-view.coffee
+++ b/lib/bookmarks-view.coffee
@@ -4,7 +4,7 @@ path = require 'path'
 
 module.exports =
 class BookmarksView extends SelectListView
-  initialize: ->
+  initialize: (@editorsBookmarks) ->
     super
     @addClass('bookmarks-view')
 
@@ -34,31 +34,31 @@ class BookmarksView extends SelectListView
 
   getFilterText: (bookmark) ->
     segments = []
-    bookmarkRow = bookmark.marker.getStartPosition().row
+    bookmarkRow = bookmark.marker.getStartBufferPosition().row
     segments.push(bookmarkRow)
-    if bufferPath = bookmark.buffer.getPath()
+    if bufferPath = bookmark.editor.getPath()
       segments.push(bufferPath)
     if lineText = @getLineText(bookmark)
       segments.push(lineText)
     segments.join(' ')
 
   getLineText: (bookmark) ->
-    bookmark.buffer.lineForRow(bookmark.marker.getStartPosition().row)?.trim()
+    bookmark.editor.lineTextForBufferRow(bookmark.marker.getStartBufferPosition().row)?.trim()
 
   populateBookmarks: ->
     bookmarks = []
-    attributes = class: 'bookmark'
-    for buffer in atom.project.getBuffers()
-      for marker in buffer.findMarkers(attributes)
-        bookmark = {marker, buffer}
-        bookmark.fitlerText = @getFilterText(bookmark)
+    for editorBookmarks in @editorsBookmarks
+      editor = editorBookmarks.editor
+      for marker in editorBookmarks.markerLayer.getMarkers()
+        bookmark = {marker, editor}
+        bookmark.filterText = @getFilterText(bookmark)
         bookmarks.push(bookmark)
     @setItems(bookmarks)
 
   viewForItem: (bookmark) ->
-    bookmarkStartRow = bookmark.marker.getStartPosition().row
-    bookmarkEndRow = bookmark.marker.getEndPosition().row
-    if filePath = bookmark.buffer.getPath()
+    bookmarkStartRow = bookmark.marker.getStartBufferPosition().row
+    bookmarkEndRow = bookmark.marker.getEndBufferPosition().row
+    if filePath = bookmark.editor.getPath()
       bookmarkLocation = "#{path.basename(filePath)}:#{bookmarkStartRow + 1}"
     else
       bookmarkLocation = "untitled:#{bookmarkStartRow + 1}"
@@ -81,7 +81,7 @@ class BookmarksView extends SelectListView
     else
       super
 
-  confirmed: ({buffer, marker}) ->
-    atom.workspace.open(buffer.getPath(), searchAllPanes: true).then (editor) ->
-      editor.setSelectedBufferRange?(marker.getRange(), autoscroll: true)
+  confirmed: ({editor, marker}) ->
+    atom.workspace.open(editor.getPath(), searchAllPanes: true).then (editor) ->
+      editor.setSelectedBufferRange?(marker.getBufferRange(), autoscroll: true)
     @cancel()

--- a/lib/bookmarks.coffee
+++ b/lib/bookmarks.coffee
@@ -11,7 +11,7 @@ class ReactBookmarks
       'bookmarks:jump-to-previous-bookmark': @jumpToPreviousBookmark
       'bookmarks:clear-bookmarks': @clearBookmarks
 
-    @markerLayer = @editor.addMarkerLayer({maintainHistory: true})
+    @markerLayer = @editor.addMarkerLayer()
     @editor.decorateMarkerLayer(@markerLayer, {type: 'line-number', class: 'bookmarked'})
     @disposables.add @editor.onDidDestroy(@destroy.bind(this))
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -4,15 +4,16 @@ BookmarksView = null
 
 module.exports =
   activate: ->
+    editorsBookmarks = []
     bookmarksView = null
 
     atom.commands.add 'atom-workspace',
       'bookmarks:view-all', ->
         unless bookmarksList?
           BookmarksView ?= require './bookmarks-view'
-          bookmarksView = new BookmarksView()
+          bookmarksView = new BookmarksView(editorsBookmarks)
         bookmarksView.toggle()
 
     atom.workspace.observeTextEditors (textEditor) ->
       Bookmarks ?= require './bookmarks'
-      bookmarks = new Bookmarks(textEditor)
+      editorsBookmarks.push(new Bookmarks(textEditor))

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
-    "emissary": "^1.2.0",
     "underscore-plus": "^1.0.0"
   },
   "devDependencies": {

--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -1,7 +1,13 @@
 {$} = require 'atom-space-pen-views'
+{values} = require 'underscore-plus'
 
 describe "Bookmarks package", ->
   [workspaceElement, editorElement, editor] = []
+
+  bookmarkedRangesForEditor = (editor) ->
+    values(editor.decorationsStateForScreenRowRange(0, editor.getLastScreenRow()))
+      .filter (decoration) -> decoration.properties.class is 'bookmarked'
+      .map (decoration) -> decoration.screenRange
 
   beforeEach ->
     spyOn(window, 'setImmediate').andCallFake (fn) -> fn()
@@ -23,135 +29,139 @@ describe "Bookmarks package", ->
     describe "point marker bookmark", ->
       it "creates a marker when toggled", ->
         editor.setCursorBufferPosition([3, 10])
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
-
+        expect(bookmarkedRangesForEditor(editor)).toEqual []
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-
-        markers = editor.findMarkers(class: 'bookmark')
-        expect(markers.length).toEqual 1
-        expect(markers[0].getBufferRange()).toEqual [[3, 10], [3, 10]]
+        expect(bookmarkedRangesForEditor(editor)).toEqual [[[3, 10], [3, 10]]]
 
       it "removes marker when toggled", ->
         editor.setCursorBufferPosition([3, 10])
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+        expect(bookmarkedRangesForEditor(editor).length).toBe 1
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
     describe "single line range marker bookmark", ->
       it "created a marker when toggled", ->
         editor.setSelectedBufferRanges([[[3, 5], [3, 10]]])
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor)).toEqual []
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
-        markers = editor.findMarkers(class: 'bookmark')
-        expect(markers.length).toEqual 1
-        expect(markers[0].getBufferRange()).toEqual [[3, 5], [3, 10]]
+        expect(bookmarkedRangesForEditor(editor)).toEqual [[[3, 5], [3, 10]]]
 
       it "removes marker when toggled", ->
         editor.setSelectedBufferRanges([[[3, 5], [3, 10]]])
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+        expect(bookmarkedRangesForEditor(editor).length).toBe 1
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
     describe "multi line range marker bookmark", ->
       it "created a marker when toggled", ->
         editor.setSelectedBufferRanges([[[1, 5], [3, 10]]])
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor)).toEqual []
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
-        markers = editor.findMarkers(class: 'bookmark')
-        expect(markers.length).toEqual 1
-        expect(markers[0].getBufferRange()).toEqual [[1, 5], [3, 10]]
+        expect(bookmarkedRangesForEditor(editor)).toEqual [[[1, 5], [3, 10]]]
 
       it "removes marker when toggled", ->
         editor.setSelectedBufferRanges([[[1, 5], [3, 10]]])
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+        expect(bookmarkedRangesForEditor(editor).length).toBe 1
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
       it "removes marker when toggled inside bookmark", ->
         editor.setSelectedBufferRanges([[[1, 5], [3, 10]]])
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+        expect(bookmarkedRangesForEditor(editor).length).toBe 1
 
         editor.setCursorBufferPosition([2, 2])
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
       it "removes marker when toggled outside bookmark on start row", ->
         editor.setSelectedBufferRanges([[[1, 5], [3, 10]]])
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+        expect(bookmarkedRangesForEditor(editor).length).toBe 1
 
         editor.setCursorBufferPosition([1, 2])
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
       it "removes marker when toggled outside bookmark on end row", ->
         editor.setSelectedBufferRanges([[[1, 5], [3, 8]]])
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 1
+        expect(bookmarkedRangesForEditor(editor).length).toBe 1
 
         editor.setCursorBufferPosition([3, 10])
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-        expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+        expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
     it "toggles proper classes on proper gutter row", ->
       editor.setCursorBufferPosition([3, 10])
       expect(editorElement.shadowRoot.querySelectorAll('.bookmarked').length).toBe 0
 
       atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+      lines = []
 
-      lines = editorElement.shadowRoot.querySelectorAll('.bookmarked')
-      expect(lines.length).toEqual 1
-      expect(lines[0]).toHaveData("buffer-row", 3)
+      waitsFor ->
+        lines = editorElement.shadowRoot.querySelectorAll('.bookmarked')
+        lines.length is 1
 
-      atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-      expect(editorElement.shadowRoot.querySelectorAll('.bookmarked').length).toBe 0
+      runs ->
+        expect(lines[0]).toHaveData("buffer-row", 3)
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+
+      waitsFor ->
+        editorElement.shadowRoot.querySelectorAll('.bookmarked').length is 0
 
     it "clears all bookmarks", ->
       editor.setCursorBufferPosition([3, 10])
       atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-      editor.setCursorBufferPosition([5, 0])
-      atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
-      atom.commands.dispatch editorElement, 'bookmarks:clear-bookmarks'
+      waitsFor ->
+        editorElement.shadowRoot.querySelectorAll('.bookmarked').length is 1
 
-      expect(editorElement.shadowRoot.querySelectorAll('.bookmarked').length).toBe 0
-      expect(editor.findMarkers(class: 'bookmark')).toHaveLength 0
+      runs ->
+        editor.setCursorBufferPosition([5, 0])
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+
+      waitsFor ->
+        editorElement.shadowRoot.querySelectorAll('.bookmarked').length is 2
+
+      runs ->
+        atom.commands.dispatch editorElement, 'bookmarks:clear-bookmarks'
+
+      waitsFor ->
+        editorElement.shadowRoot.querySelectorAll('.bookmarked').length is 0
 
   describe "when a bookmark is invalidated", ->
     it "creates a marker when toggled", ->
       editor.setCursorBufferPosition([3, 10])
-      expect(editor.findMarkers(class: 'bookmark').length).toEqual 0
+      expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
       atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
-      markers = editor.findMarkers(class: 'bookmark')
-      expect(markers.length).toEqual 1
+      expect(bookmarkedRangesForEditor(editor).length).toBe 1
 
       editor.setText('')
-      markers = editor.findMarkers(class: 'bookmark')
-      expect(markers.length).toEqual 0
+      expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
   describe "jumping between bookmarks", ->
 


### PR DESCRIPTION
This PR refactors the entire package so that we can use `MarkerLayer`s and decorate them, instead of doing so for every marker. This is necessary for the upcoming `DisplayLayer` refactoring, which will deprecate marking a range and assigning custom properties at the same time.

During this refactoring, I took the opportunity to drop `emissary` and use `event-kit` instead.

/cc: @nathansobo 