### PR TITLE
Fix issues #31 #33 #59 

### DIFF
--- a/lib/bookmarks.coffee
+++ b/lib/bookmarks.coffee
@@ -17,6 +17,7 @@ class Bookmarks
     markerLayerOptions = if @editor.displayLayer? then {persistent: true} else {maintainHistory: true}
     @markerLayer ?= @editor.addMarkerLayer(markerLayerOptions)
     @decorationLayer = @editor.decorateMarkerLayer(@markerLayer, {type: 'line-number', class: 'bookmarked'})
+    @editor.decorateMarkerLayer(@markerLayer, {type: 'line', class: 'bookmarked'})
     @disposables.add @editor.onDidDestroy(@destroy.bind(this))
 
   destroy: ->

--- a/lib/bookmarks.coffee
+++ b/lib/bookmarks.coffee
@@ -33,8 +33,7 @@ class Bookmarks
 
   toggleBookmark: =>
     cursors = @editor.getCursors()
-    for cursor in cursors
-      range = @editor.getSelectedBufferRange()
+    for range in @editor.getSelectedBufferRanges()
       bookmarks = @markerLayer.findMarkers(intersectsBufferRowRange: [range.start.row, range.end.row])
 
       if bookmarks?.length > 0

--- a/lib/bookmarks.coffee
+++ b/lib/bookmarks.coffee
@@ -17,7 +17,7 @@ class Bookmarks
     markerLayerOptions = if @editor.displayLayer? then {persistent: true} else {maintainHistory: true}
     @markerLayer ?= @editor.addMarkerLayer(markerLayerOptions)
     @decorationLayer = @editor.decorateMarkerLayer(@markerLayer, {type: 'line-number', class: 'bookmarked'})
-    @editor.decorateMarkerLayer(@markerLayer, {type: 'line', class: 'bookmarked'})
+    @decorationLayerLine = @editor.decorateMarkerLayer(@markerLayer, {type: 'line', class: 'bookmarked'})
     @disposables.add @editor.onDidDestroy(@destroy.bind(this))
 
   destroy: ->
@@ -26,6 +26,7 @@ class Bookmarks
 
   deactivate: ->
     @decorationLayer.destroy()
+    @decorationLayerLine.destroy()
     @disposables.dispose()
 
   serialize: ->
@@ -70,7 +71,12 @@ class Bookmarks
       if marker.getBufferRange then marker.getBufferRange().start.row else marker
 
     bookmarkIndex--
-    bookmarkIndex = markers.length - 1 if bookmarkIndex < 0
+
+    if bookmarkIndex < 0
+      if atom.config.get('bookmarks.wrapBuffer')
+        bookmarkIndex = markers.length - 1
+      else
+        null
 
     markers[bookmarkIndex]
 
@@ -83,7 +89,12 @@ class Bookmarks
       if marker.getBufferRange then marker.getBufferRange().start.row else marker
 
     bookmarkIndex++ if markers[bookmarkIndex] and markers[bookmarkIndex].getBufferRange().start.row is bufferRow
-    bookmarkIndex = 0 if bookmarkIndex >= markers.length
+
+    if bookmarkIndex >= markers.length
+      if atom.config.get('bookmarks.wrapBuffer')
+        bookmarkIndex = 0
+      else
+        null
 
     markers[bookmarkIndex]
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -7,6 +7,14 @@ editorsBookmarks = null
 disposables = null
 
 module.exports =
+
+  config:
+    wrapBuffer:
+      title: 'Wrap Buffer'
+      description: 'When enabled, jumping to next bookmark after the last one will go back to the first bookmark, and jumping to the previous bookmark before the first one will go the last one. '
+      type: 'boolean'
+      default: true
+
   activate: (bookmarksByEditorId) ->
     editorsBookmarks = []
     bookmarksView = null


### PR DESCRIPTION
- Add ability to create multiple bookmarks with multiple cursors

- Add 'bookmarked' css tag to the `line` as well as the `line-number`, allowing customization, ie:
```
atom-text-editor::shadow .line.bookmarked {
  background-color: rgba(0, 153, 204, 0.3)
}
```

- Create option '`Wrap Buffer`', true by default, to block wrapping around buffer 
