### PR TITLE
Add an option to cycle through bookmarks

### DIFF
--- a/lib/bookmarks.coffee
+++ b/lib/bookmarks.coffee
@@ -70,7 +70,12 @@ class Bookmarks
       if marker.getBufferRange then marker.getBufferRange().start.row else marker
 
     bookmarkIndex--
-    bookmarkIndex = markers.length - 1 if bookmarkIndex < 0
+
+    if bookmarkIndex < 0
+      if atom.config.get('bookmarks.wrapBuffer')
+        bookmarkIndex = markers.length - 1
+      else
+        null
 
     markers[bookmarkIndex]
 
@@ -83,7 +88,12 @@ class Bookmarks
       if marker.getBufferRange then marker.getBufferRange().start.row else marker
 
     bookmarkIndex++ if markers[bookmarkIndex] and markers[bookmarkIndex].getBufferRange().start.row is bufferRow
-    bookmarkIndex = 0 if bookmarkIndex >= markers.length
+
+    if bookmarkIndex >= markers.length
+      if atom.config.get('bookmarks.wrapBuffer')
+        bookmarkIndex = 0
+      else
+        null
 
     markers[bookmarkIndex]
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -7,6 +7,14 @@ editorsBookmarks = null
 disposables = null
 
 module.exports =
+
+  config:
+    wrapBuffer:
+      title: 'Wrap Buffer'
+      description: 'When enabled, jumping to next or previous bookmark can wrap around the buffer.'
+      type: 'boolean'
+      default: true
+
   activate: (bookmarksByEditorId) ->
     editorsBookmarks = []
     bookmarksView = null

--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -217,7 +217,8 @@ describe "Bookmarks package", ->
         editor.setSelectedBufferRanges([[[8, 4], [10, 0]]])
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
-      it "jump-to-next-bookmark finds next bookmark", ->
+      it "jump-to-next-bookmark finds next bookmark with wrapping", ->
+        editor.config.set('bookmarks.wrapBuffer', true)
         editor.setCursorBufferPosition([0, 0])
 
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-next-bookmark'
@@ -234,7 +235,8 @@ describe "Bookmarks package", ->
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-next-bookmark'
         expect(editor.getLastCursor().getBufferPosition()).toEqual [2, 0]
 
-      it "jump-to-previous-bookmark finds previous bookmark", ->
+      it "jump-to-previous-bookmark finds previous bookmark with wrapping", ->
+        editor.config.set('bookmarks.wrapBuffer', true)
         editor.setCursorBufferPosition([0, 0])
 
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
@@ -250,6 +252,42 @@ describe "Bookmarks package", ->
 
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
         expect(editor.getLastCursor().getMarker().getBufferRange()).toEqual [[8, 4], [10, 0]]
+
+      it "jump-to-next-bookmark locks without wrapping", ->
+        editor.config.set('bookmarks.wrapBuffer', false)
+        editor.setCursorBufferPosition([0, 0])
+
+        atom.commands.dispatch editorElement, 'bookmarks:jump-to-next-bookmark'
+        expect(editor.getLastCursor().getBufferPosition()).toEqual [2, 0]
+
+        atom.commands.dispatch editorElement, 'bookmarks:jump-to-next-bookmark'
+        expect(editor.getLastCursor().getMarker().getBufferRange()).toEqual [[8, 4], [10, 0]]
+
+        atom.commands.dispatch editorElement, 'bookmarks:jump-to-next-bookmark'
+        expect(atom.beep.callCount).toBe 1
+
+        editor.setCursorBufferPosition([11, 0])
+
+        atom.commands.dispatch editorElement, 'bookmarks:jump-to-next-bookmark'
+        expect(atom.beep.callCount).toBe 2
+
+      it "jump-to-previous-bookmark locks without wrapping", ->
+        editor.config.set('bookmarks.wrapBuffer', false)
+        editor.setCursorBufferPosition([11, 0])
+
+        atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
+        expect(editor.getLastCursor().getMarker().getBufferRange()).toEqual [[8, 4], [10, 0]]
+
+        atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
+        expect(editor.getLastCursor().getBufferPosition()).toEqual [2, 0]
+
+        atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
+        expect(atom.beep.callCount).toBe 1
+
+        editor.setCursorBufferPosition([0, 0])
+
+        atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
+        expect(atom.beep.callCount).toBe 2
 
   describe "browsing bookmarks", ->
     it "displays a select list of all bookmarks", ->


### PR DESCRIPTION
Issues #31 and #50 show that not all users agree on the expected behavior when bottom of buffer has been reached. Should we cycle to top of buffer or stay at the bottom with a 'bip' for a better sense of place? This pull request implements an option (the first one for the bookmarks package!); default behavior is unchanged.

Feel free to change the wording; English is not my mother tongue.

Jasmine specs have been added.