### PR TITLE
Clear pending state when setting a bookmark (plus some defensive code)

### DIFF
--- a/lib/bookmarks-view.coffee
+++ b/lib/bookmarks-view.coffee
@@ -48,6 +48,7 @@ class BookmarksView extends SelectListView
     bookmarks = []
     for editorBookmarks in @editorsBookmarks
       editor = editorBookmarks.editor
+      continue if editor not in atom.workspace.getTextEditors()
       for marker in editorBookmarks.markerLayer.getMarkers()
         bookmark = {marker, editor}
         bookmark.filterText = @getFilterText(bookmark)

--- a/lib/bookmarks.coffee
+++ b/lib/bookmarks.coffee
@@ -41,6 +41,9 @@ class Bookmarks
       else
         @createBookmarkMarker(range)
 
+    if atom.workspace.getActivePane().getPendingItem() is @editor
+      atom.workspace.getActivePane().clearPendingItem();
+
   clearBookmarks: =>
     bookmark.destroy() for bookmark in @markerLayer.getMarkers()
 


### PR DESCRIPTION
#58, #57 are related to cases when the bookmark list contain bookmarks for editors that don't exist anymore. There are two cases:

### When the editor was pending
I propose to clear the pending status when a bookmark is set. After all, if you set a bookmark on a file, you probably don't want it to disappear when previewing another file.

### Other situations where we don't have a clear scenario
I encountered such situations, yet couldn't reproduce them. I propose some simple defensive code: verify that editors are still alive before putting their bookmarks in the list.
