### PR TITLE
Decorate bookmarked lines

### DIFF
--- a/lib/bookmarks.coffee
+++ b/lib/bookmarks.coffee
@@ -18,6 +18,7 @@ class Bookmarks
     @markerLayer ?= @editor.addMarkerLayer(markerLayerOptions)
     @decorationLayer = @editor.decorateMarkerLayer(@markerLayer, {type: 'line-number', class: 'bookmarked'})
     @decorationLayerLine = @editor.decorateMarkerLayer(@markerLayer, {type: 'line', class: 'bookmarked'})
+    @decorationLayerHighlight = @editor.decorateMarkerLayer(@markerLayer, {type: 'highlight', class: 'bookmarked'})
     @disposables.add @editor.onDidDestroy(@destroy.bind(this))
 
   destroy: ->
@@ -27,6 +28,7 @@ class Bookmarks
   deactivate: ->
     @decorationLayer.destroy()
     @decorationLayerLine.destroy()
+    @decorationLayerHighlight.destroy()
     @disposables.dispose()
 
   serialize: ->

--- a/lib/bookmarks.coffee
+++ b/lib/bookmarks.coffee
@@ -17,6 +17,7 @@ class Bookmarks
     markerLayerOptions = if @editor.displayLayer? then {persistent: true} else {maintainHistory: true}
     @markerLayer ?= @editor.addMarkerLayer(markerLayerOptions)
     @decorationLayer = @editor.decorateMarkerLayer(@markerLayer, {type: 'line-number', class: 'bookmarked'})
+    @decorationLayerLine = @editor.decorateMarkerLayer(@markerLayer, {type: 'line', class: 'bookmarked'})
     @disposables.add @editor.onDidDestroy(@destroy.bind(this))
 
   destroy: ->
@@ -25,6 +26,7 @@ class Bookmarks
 
   deactivate: ->
     @decorationLayer.destroy()
+    @decorationLayerLine.destroy()
     @disposables.dispose()
 
   serialize: ->

--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -124,6 +124,7 @@ describe "Bookmarks package", ->
 
       waitsFor ->
         editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 1
+      waitsFor ->
         lines = editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked')
         lines.length is 1
 
@@ -133,6 +134,7 @@ describe "Bookmarks package", ->
 
       waitsFor ->
         editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 1
+      waitsFor ->
         editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length is 0
 
     it "clears all bookmarks", ->
@@ -141,6 +143,7 @@ describe "Bookmarks package", ->
 
       waitsFor ->
         editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 1
+      waitsFor ->
         editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length is 1
 
       runs ->
@@ -149,6 +152,7 @@ describe "Bookmarks package", ->
 
       waitsFor ->
         editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 2
+      waitsFor ->
         editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length is 2
 
       runs ->
@@ -156,6 +160,7 @@ describe "Bookmarks package", ->
 
       waitsFor ->
         editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 0
+      waitsFor ->
         editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length is 0
 
   describe "when a bookmark is invalidated", ->

--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -115,7 +115,7 @@ describe "Bookmarks package", ->
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
         expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
-    it "toggles proper classes on proper gutter and line row", ->
+    it "toggles proper classes on proper gutter, line row and highlight on point bookmark", ->
       editor.setCursorBufferPosition([3, 10])
       expect(editorElement.shadowRoot.querySelectorAll('.bookmarked').length).toBe 0
 
@@ -123,19 +123,49 @@ describe "Bookmarks package", ->
       lines = []
 
       waitsFor ->
-        editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 1
+        lines = editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked')
+        lines.length is 1
+
+      runs ->
+        expect(editorElement.shadowRoot.querySelectorAll('.highlight.bookmarked').length).toBe 0
+        expect(editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length).toBe 1
+        expect(editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length).toBe 1
+        expect(lines[0]).toHaveData("buffer-row", 3)
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+
+      waitsFor ->
+        editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length is 0
+
+      runs ->
+        expect(editorElement.shadowRoot.querySelectorAll('.highlight.bookmarked').length).toBe 0
+        expect(editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length).toBe 0
+        expect(editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length).toBe 0
+
+    it "toggles proper classes on proper gutter, line row and highlight on range bookmark", ->
+      editor.setSelectedBufferRanges([[[3, 5], [3, 10]]])
+      expect(editorElement.shadowRoot.querySelectorAll('.bookmarked').length).toBe 0
+
+      atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+      lines = []
+
       waitsFor ->
         lines = editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked')
         lines.length is 1
 
       runs ->
+        expect(editorElement.shadowRoot.querySelectorAll('.highlight.bookmarked').length).toBe 1
+        expect(editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length).toBe 1
+        expect(editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length).toBe 1
         expect(lines[0]).toHaveData("buffer-row", 3)
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
       waitsFor ->
-        editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 1
-      waitsFor ->
         editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length is 0
+
+      runs ->
+        expect(editorElement.shadowRoot.querySelectorAll('.highlight.bookmarked').length).toBe 0
+        expect(editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length).toBe 0
+        expect(editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length).toBe 0
 
     it "clears all bookmarks", ->
       editor.setCursorBufferPosition([3, 10])

--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -7,6 +7,7 @@ describe "Bookmarks package", ->
   bookmarkedRangesForEditor = (editor) ->
     values(editor.decorationsStateForScreenRowRange(0, editor.getLastScreenRow()))
       .filter (decoration) -> decoration.properties.class is 'bookmarked'
+      .filter (decoration) -> decoration.properties.type is 'line-number'
       .map (decoration) -> decoration.screenRange
 
   beforeEach ->
@@ -114,7 +115,7 @@ describe "Bookmarks package", ->
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
         expect(bookmarkedRangesForEditor(editor).length).toBe 0
 
-    it "toggles proper classes on proper gutter row", ->
+    it "toggles proper classes on proper gutter and line row", ->
       editor.setCursorBufferPosition([3, 10])
       expect(editorElement.shadowRoot.querySelectorAll('.bookmarked').length).toBe 0
 
@@ -122,7 +123,8 @@ describe "Bookmarks package", ->
       lines = []
 
       waitsFor ->
-        lines = editorElement.shadowRoot.querySelectorAll('.bookmarked')
+        editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 1
+        lines = editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked')
         lines.length is 1
 
       runs ->
@@ -130,27 +132,31 @@ describe "Bookmarks package", ->
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
       waitsFor ->
-        editorElement.shadowRoot.querySelectorAll('.bookmarked').length is 0
+        editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 1
+        editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length is 0
 
     it "clears all bookmarks", ->
       editor.setCursorBufferPosition([3, 10])
       atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
       waitsFor ->
-        editorElement.shadowRoot.querySelectorAll('.bookmarked').length is 1
+        editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 1
+        editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length is 1
 
       runs ->
         editor.setCursorBufferPosition([5, 0])
         atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
 
       waitsFor ->
-        editorElement.shadowRoot.querySelectorAll('.bookmarked').length is 2
+        editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 2
+        editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length is 2
 
       runs ->
         atom.commands.dispatch editorElement, 'bookmarks:clear-bookmarks'
 
       waitsFor ->
-        editorElement.shadowRoot.querySelectorAll('.bookmarked').length is 0
+        editorElement.shadowRoot.querySelectorAll('.line.bookmarked').length is 0
+        editorElement.shadowRoot.querySelectorAll('.line-number.bookmarked').length is 0
 
   describe "when a bookmark is invalidated", ->
     it "creates a marker when toggled", ->


### PR DESCRIPTION
As per request #33, this commit adds the `.bookmarked` class to `.line` as well as `.line-number` elements.
This allows to decorate lines. For example:

``` less
atom-text-editor::shadow .line.bookmarked {
  background-color: rgba(0, 153, 204, 0.3);
}
```

![image](https://cloud.githubusercontent.com/assets/1157957/16169889/4a7f62f4-353f-11e6-8551-d749ff79e4ed.png)
