### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/styles/bookmarks.less
+++ b/styles/bookmarks.less
@@ -1,7 +1,6 @@
 @import "octicon-utf-codes.less";
 
-atom-text-editor,
-atom-text-editor::shadow {
+atom-text-editor {
   .gutter .line-number.bookmarked .icon-right {
     visibility: visible;
 


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

/cc: @simurai