### PR TITLE
Fix bookmarked range duplication bug

### DIFF
--- a/lib/bookmarks.js
+++ b/lib/bookmarks.js
@@ -43,7 +43,7 @@ export default class Bookmarks {
           bookmark.destroy()
         }
       } else {
-        const bookmark = this.markerLayer.markBufferRange(range, {invalidate: "surround"})
+        const bookmark = this.markerLayer.markBufferRange(range, {invalidate: "surround", exclusive: true})
         this.disposables.add(bookmark.onDidChange(({isValid}) => {
           if (!isValid) {
             bookmark.destroy()

--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -314,6 +314,30 @@ describe "Bookmarks package", ->
         atom.commands.dispatch editorElement, 'bookmarks:jump-to-previous-bookmark'
         expect(editor.getLastCursor().getMarker().getBufferRange()).toEqual [[8, 4], [10, 0]]
 
+  describe "when inserting text next to the bookmark", ->
+    beforeEach ->
+      editor.setSelectedBufferRanges([[[3, 10], [3, 25]]])
+      expect(bookmarkedRangesForEditor(editor).length).toBe 0
+
+      atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+      expect(bookmarkedRangesForEditor(editor).length).toBe 1
+
+    it "moves the bookmarked range forward when typing in the start", ->
+      editor.setCursorBufferPosition([3, 10])
+      editor.insertText('Hello')
+      editor.setCursorBufferPosition([0, 0])
+
+      atom.commands.dispatch editorElement, 'bookmarks:jump-to-next-bookmark'
+      expect(editor.getLastCursor().getMarker().getBufferRange()).toEqual [[3, 15], [3, 30]]
+
+    it "doesnt extend the bookmarked range when typing in the end", ->
+      editor.setCursorBufferPosition([3, 25])
+      editor.insertText('Hello')
+      editor.setCursorBufferPosition([0, 0])
+
+      atom.commands.dispatch editorElement, 'bookmarks:jump-to-next-bookmark'
+      expect(editor.getLastCursor().getMarker().getBufferRange()).toEqual [[3, 10], [3, 25]]
+
   describe "browsing bookmarks", ->
     it "displays a select list of all bookmarks", ->
       editor.setCursorBufferPosition([0])


### PR DESCRIPTION
### Description of the Change

Changes the `DisplayMarkerLayer` of a bookmark to use exclusive insertion strategy. This means that insertions at the start or end of the marked range should be interpreted as happening outside the `DisplayMarkerLayer` and not extend the range. 
The current behavior of extending the range when typing outside has many points of failure as discussed in https://github.com/atom/bookmarks/issues/62.

Gif of behavior after the change:
![bookmarks fix](https://cloud.githubusercontent.com/assets/1058982/19835497/25e2ce5a-9e89-11e6-8920-1ba27088df76.gif)
### Alternate Designs

N/A
### Benefits
- Makes bookmarks behave more like sublime.
- Adds a test for this behavior.

### Possible Drawbacks

Someone depends on the current behavior.
### Applicable Issues

Fixes https://github.com/atom/bookmarks/issues/62

/cc: @as-cii 
