### PR TITLE
Add "Select to Next / Previous Bookmark" commands

### DIFF
--- a/lib/bookmarks.js
+++ b/lib/bookmarks.js
@@ -16,6 +16,8 @@ export default class Bookmarks {
       "bookmarks:toggle-bookmark": this.toggleBookmark.bind(this),
       "bookmarks:jump-to-next-bookmark": this.jumpToNextBookmark.bind(this),
       "bookmarks:jump-to-previous-bookmark": this.jumpToPreviousBookmark.bind(this),
+      "bookmarks:select-to-next-bookmark": this.selectToNextBookmark.bind(this),
+      "bookmarks:select-to-previous-bookmark": this.selectToPreviousBookmark.bind(this),
       "bookmarks:clear-bookmarks": this.clearBookmarks.bind(this)
     }))
     this.disposables.add(this.editor.onDidDestroy(this.destroy.bind(this)))
@@ -78,6 +80,28 @@ export default class Bookmarks {
       const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row < bufferRow) || markers[0]
       this.editor.setSelectedBufferRange(bookmarkMarker.getBufferRange(), {autoscroll: false})
       this.editor.scrollToCursorPosition()
+    } else {
+      atom.beep()
+    }
+  }
+  
+  selectToNextBookmark () {
+    if (this.markerLayer.getMarkerCount() > 0) {
+      const bufferRow = this.editor.getLastCursor().getMarker().getStartBufferPosition().row
+      const markers = this.markerLayer.getMarkers().sort((a, b) => a.compare(b))
+      const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row > bufferRow) || markers[0]
+      this.editor.setSelectedBufferRange([bookmarkMarker.getHeadBufferPosition(), this.editor.getCursorBufferPosition()], {autoscroll: false})
+    } else {
+      atom.beep()
+    }
+  }
+
+  selectToPreviousBookmark () {
+    if (this.markerLayer.getMarkerCount() > 0) {
+      const bufferRow = this.editor.getLastCursor().getMarker().getStartBufferPosition().row
+      const markers = this.markerLayer.getMarkers().sort((a, b) => b.compare(a))
+      const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row < bufferRow) || markers[0]
+      this.editor.setSelectedBufferRange([this.editor.getCursorBufferPosition(), bookmarkMarker.getHeadBufferPosition()], {autoscroll: false})
     } else {
       atom.beep()
     }

--- a/lib/bookmarks.js
+++ b/lib/bookmarks.js
@@ -89,8 +89,12 @@ export default class Bookmarks {
     if (this.markerLayer.getMarkerCount() > 0) {
       const bufferRow = this.editor.getLastCursor().getMarker().getStartBufferPosition().row
       const markers = this.markerLayer.getMarkers().sort((a, b) => a.compare(b))
-      const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row > bufferRow) || markers[0]
-      this.editor.setSelectedBufferRange([bookmarkMarker.getHeadBufferPosition(), this.editor.getCursorBufferPosition()], {autoscroll: false})
+      const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row > bufferRow)
+      if (!bookmarkMarker) {
+          atom.beep()
+      } else {
+          this.editor.setSelectedBufferRange([bookmarkMarker.getHeadBufferPosition(), this.editor.getCursorBufferPosition()], {autoscroll: false})
+      }
     } else {
       atom.beep()
     }
@@ -100,8 +104,12 @@ export default class Bookmarks {
     if (this.markerLayer.getMarkerCount() > 0) {
       const bufferRow = this.editor.getLastCursor().getMarker().getStartBufferPosition().row
       const markers = this.markerLayer.getMarkers().sort((a, b) => b.compare(a))
-      const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row < bufferRow) || markers[0]
-      this.editor.setSelectedBufferRange([this.editor.getCursorBufferPosition(), bookmarkMarker.getHeadBufferPosition()], {autoscroll: false})
+      const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row < bufferRow)
+      if (!bookmarkMarker) {
+          atom.beep()
+      } else {
+          this.editor.setSelectedBufferRange([this.editor.getCursorBufferPosition(), bookmarkMarker.getHeadBufferPosition()], {autoscroll: false})
+      }
     } else {
       atom.beep()
     }

--- a/menus/bookmarks.cson
+++ b/menus/bookmarks.cson
@@ -9,6 +9,8 @@
           { 'label': 'Toggle Bookmark', 'command': 'bookmarks:toggle-bookmark' }
           { 'label': 'Jump to Next Bookmark', 'command': 'bookmarks:jump-to-next-bookmark' }
           { 'label': 'Jump to Previous Bookmark', 'command': 'bookmarks:jump-to-previous-bookmark' }
+          { 'label': 'Select to Next Bookmark', 'command': 'bookmarks:select-to-next-bookmark' }
+          { 'label': 'Select to Previous Bookmark', 'command': 'bookmarks:select-to-previous-bookmark' }
         ]
       }
     ]

--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -448,3 +448,33 @@ describe "Bookmarks package", ->
 
       expect(bookmarkedRangesForEditor(editor)).toEqual []
       expect(bookmarkedRangesForEditor(editor2)).toEqual []
+
+  describe "selecting bookmarks", ->
+
+    it "doesnt die when no bookmarks", ->
+      editor.setCursorBufferPosition([5, 10])
+
+      atom.commands.dispatch editorElement, 'bookmarks:select-to-next-bookmark'
+      expect(editor.getLastCursor().getBufferPosition()).toEqual [5, 10]
+      expect(atom.beep.callCount).toBe 1
+
+      atom.commands.dispatch editorElement, 'bookmarks:select-to-previous-bookmark'
+      expect(editor.getLastCursor().getBufferPosition()).toEqual [5, 10]
+      expect(atom.beep.callCount).toBe 2
+
+    describe "with one bookmark", ->
+      beforeEach ->
+        editor.setCursorBufferPosition([2, 0])
+        atom.commands.dispatch editorElement, 'bookmarks:toggle-bookmark'
+
+      it "select-to-next-bookmark selects to the right place", ->
+        editor.setCursorBufferPosition([0, 0])
+
+        atom.commands.dispatch editorElement, 'bookmarks:select-to-next-bookmark'
+        expect(editor.getSelectedBufferRange()).toEqual([[0, 0], [2, 0]])
+
+      it "select-to-previous-bookmark selects to the right place", ->
+        editor.setCursorBufferPosition([4, 0])
+
+        atom.commands.dispatch editorElement, 'bookmarks:select-to-previous-bookmark'
+        expect(editor.getSelectedBufferRange()).toEqual([[4, 0], [2, 0]])


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR adds two new commands to the package, `Select to Next Bookmark` and `Select to Previous Bookmark`, which creates a selection range from the cursor position to the next/previous bookmark.

### Alternate Designs

It is a simple design, because the command is simple. Just using the already provided `setSelectedBufferRange` function to create the selection.

### Benefits

You can take advantage of bookmarks to also select areas that you intend to Copy/Replace text.

### Possible Drawbacks

Nothing at all, since nothing has changed in the already existing code. The two new commands are isolated.

### Applicable Issues

This PR Closes #24 .
