### PR TITLE
Select to the only bookmark

### DIFF
--- a/lib/bookmarks.js
+++ b/lib/bookmarks.js
@@ -89,7 +89,7 @@ export default class Bookmarks {
     if (this.markerLayer.getMarkerCount() > 0) {
       const bufferRow = this.editor.getLastCursor().getMarker().getStartBufferPosition().row
       const markers = this.markerLayer.getMarkers().sort((a, b) => a.compare(b))
-      const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row > bufferRow)
+      const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row > bufferRow) || markers[0]
       if (!bookmarkMarker) {
         atom.beep()
       } else {
@@ -104,7 +104,7 @@ export default class Bookmarks {
     if (this.markerLayer.getMarkerCount() > 0) {
       const bufferRow = this.editor.getLastCursor().getMarker().getStartBufferPosition().row
       const markers = this.markerLayer.getMarkers().sort((a, b) => b.compare(a))
-      const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row < bufferRow)
+      const bookmarkMarker = markers.find((marker) => marker.getBufferRange().start.row < bufferRow) || markers[0]
       if (!bookmarkMarker) {
         atom.beep()
       } else {

--- a/spec/bookmarks-view-spec.coffee
+++ b/spec/bookmarks-view-spec.coffee
@@ -472,8 +472,20 @@ describe "Bookmarks package", ->
         atom.commands.dispatch editorElement, 'bookmarks:select-to-next-bookmark'
         expect(editor.getSelectedBufferRange()).toEqual([[0, 0], [2, 0]])
 
+      it "select-to-next-bookmark selects to the only bookmark", ->
+        editor.setCursorBufferPosition([4, 0])
+
+        atom.commands.dispatch editorElement, 'bookmarks:select-to-next-bookmark'
+        expect(editor.getSelectedBufferRange()).toEqual([[4, 0], [2, 0]])
+
       it "select-to-previous-bookmark selects to the right place", ->
         editor.setCursorBufferPosition([4, 0])
 
         atom.commands.dispatch editorElement, 'bookmarks:select-to-previous-bookmark'
         expect(editor.getSelectedBufferRange()).toEqual([[4, 0], [2, 0]])
+
+      it "select-to-previous-bookmark selects to the only bookmark", ->
+        editor.setCursorBufferPosition([0, 0])
+
+        atom.commands.dispatch editorElement, 'bookmarks:select-to-previous-bookmark'
+        expect(editor.getSelectedBufferRange()).toEqual([[0, 0], [2, 0]])


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR adds update the `Select to Next Bookmark` and `Select to Previous Bookmark`, to work even if the only bookmark is positioned _in the other direction_

### Alternate Designs

It follows the same behavior of `Jump to Next/Previous Bookmark` commands.

### Benefits

You can take advantage of the selection commands even you don't know exactly if the cursor is above or below

### Possible Drawbacks

Nothing at all, since it follows the same behavior as `Jump` commands

### Applicable Issues

This PR closes #94 .
